### PR TITLE
Performance optimisation for k-modes

### DIFF
--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -89,11 +89,11 @@ def _k_prototypes_iter(Xnum, Xcat, centroids, cl_attr_sum, cl_attr_freq,
             Xnum[ipoint], ipoint, clust, old_clust, cl_attr_sum, membship
         )
         cl_attr_freq, membship = kmodes.move_point_cat(
-            Xcat[ipoint], ipoint, clust, old_clust, cl_attr_freq, membship
+            Xcat[ipoint], ipoint, clust, old_clust, cl_attr_freq, membship, centroids[1]
         )
 
-        # Update new and old centroids by choosing mean for numerical
-        # and mode for categorical attributes.
+        # Update old and new centroids for numerical attributes using the mean
+        # of all values
         for iattr in range(len(Xnum[ipoint])):
             for curc in (clust, old_clust):
                 if sum(membship[curc, :]):
@@ -101,11 +101,7 @@ def _k_prototypes_iter(Xnum, Xcat, centroids, cl_attr_sum, cl_attr_freq,
                         cl_attr_sum[curc, iattr] / sum(membship[curc, :])
                 else:
                     centroids[0][curc, iattr] = 0.
-        for iattr in range(len(Xcat[ipoint])):
-            for curc in (clust, old_clust):
-                centroids[1][curc, iattr] = \
-                    kmodes.get_max_value_key(cl_attr_freq[curc][iattr])
-
+        
         # In case of an empty cluster, reinitialize with a random point
         # from largest cluster.
         if sum(membship[old_clust, :]) == 0:


### PR DESCRIPTION
Hi Nico, thanks for making this code available! I'm using it for clustering analysis across a large dataset and I came across this optimisation for the k-modes algorithm that might be of use. It's based on the observation that when updating the attribute/value counts, it's generally unnecessary to recalculate the centroids from scratch after every change: only increments that establish a new mode, or decrements against the current mode can actually change the centroid value. So for most cases we can skip the recalculation and that's what this pull request does.

All existing unit tests are passing, and I noticed some good performance gains against my multi-million row dataset. Note there is a change to one of the existing method signatures- if you think there's a way to write this in a style that better suits your codebase, go for it. I would be happy to assist :)

Again, thanks for open-sourcing this code!

Cheers,

Ian