### PR TITLE
Adding epoch cost functionality to both algorithms.

### DIFF
--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -390,16 +390,18 @@ class KModes(BaseEstimator, ClusterMixin):
         """
 
         random_state = check_random_state(self.random_state)
-        self._enc_cluster_centroids, self._enc_map, self.labels_,\
-        self.cost_, self.n_iter_, self.epoch_costs_ = k_modes(X,
-                                                          self.n_clusters,
-                                                          self.max_iter,
-                                                          self.cat_dissim,
-                                                          self.init,
-                                                          self.n_init,
-                                                          self.verbose,
-                                                          random_state,
-                                                          self.n_jobs)
+        self._enc_cluster_centroids, self._enc_map, self.labels_, self.cost_, \
+        self.n_iter_, self.epoch_costs_ = k_modes(
+                X,
+                self.n_clusters,
+                self.max_iter,
+                self.cat_dissim,
+                self.init,
+                self.n_init,
+                self.verbose,
+                random_state,
+                self.n_jobs,
+        )
         return self
 
     def fit_predict(self, X, y=None, **kwargs):

--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -217,8 +217,10 @@ def k_modes_single(X, n_clusters, n_points, n_attrs, max_iter, dissim, init, ini
     itr = 0
     labels = None
     converged = False
-    cost = np.Inf
-    epoch_costs = []
+
+    _, cost = _labels_cost(X, centroids, dissim, membship)
+
+    epoch_costs = [cost]
     while itr <= max_iter and not converged:
         itr += 1
         centroids, moves = _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim, random_state)

--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -231,8 +231,11 @@ def k_prototypes_single(Xnum, Xcat, nnumattrs, ncatattrs, n_clusters, n_points,
     itr = 0
     labels = None
     converged = False
-    cost = np.Inf
-    epoch_costs = []
+
+    _, cost = _labels_cost(Xnum, Xcat, centroids,
+                           num_dissim, cat_dissim, gamma, membship)
+
+    epoch_costs = [cost]
     while itr <= max_iter and not converged:
         itr += 1
         centroids, moves = _k_prototypes_iter(Xnum, Xcat, centroids,

--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -229,7 +229,7 @@ def k_prototypes(X, categorical, n_clusters, max_iter, num_dissim, cat_dissim,
                 stdx = np.std(Xnum, axis=0)
                 centroids = [
                     meanx + np.random.randn(n_clusters, nnumattrs) * stdx,
-                    centroids)
+                    centroids
                 ]
 
             if verbose:
@@ -415,8 +415,8 @@ class KPrototypes(kmodes.KModes):
 
         # If self.gamma is None, gamma will be automatically determined from
         # the data. The function below returns its value.
-        self._enc_cluster_centroids, self._enc_map,
-        self.labels_, self.cost_, self.n_iter_,
+        self._enc_cluster_centroids, self._enc_map, \
+        self.labels_, self.cost_, self.n_iter_, \
         self.epoch_costs_, self.gamma = k_prototypes(X,
                                             categorical,
                                             self.n_clusters,

--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -451,20 +451,22 @@ class KPrototypes(kmodes.KModes):
         random_state = check_random_state(self.random_state)
         # If self.gamma is None, gamma will be automatically determined from
         # the data. The function below returns its value.
-        self._enc_cluster_centroids, self._enc_map, \
-        self.labels_, self.cost_, self.n_iter_, \
-        self.epoch_costs_, self.gamma = k_prototypes(X,
-                                            categorical,
-                                            self.n_clusters,
-                                            self.max_iter,
-                                            self.num_dissim,
-                                            self.cat_dissim,
-                                            self.gamma,
-                                            self.init,
-                                            self.n_init,
-                                            self.verbose,
-                                            random_state,
-                                            self.n_jobs)
+        self._enc_cluster_centroids, self._enc_map, self.labels_, self.cost_, \
+        self.n_iter_, self.epoch_costs_, self.gamma = k_prototypes(
+                X,
+                categorical,
+                self.n_clusters,
+                self.max_iter,
+                self.num_dissim,
+                self.cat_dissim,
+                self.gamma,
+                self.init,
+                self.n_init,
+                self.verbose,
+                random_state,
+                self.n_jobs
+        )
+
         return self
 
     def predict(self, X, categorical=None):


### PR DESCRIPTION
Following issue #59, I have added the ability to access the epoch costs in the 'best' iteration of either algorithm. This is done by using the `epoch_costs_` attribute of a `KModes` or `KPrototypes` object.

I am open to suggestions with regard to my writing style and I hope to hear from you soon.

Cheers