### PR TITLE
Parallel

### DIFF
--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -172,7 +172,7 @@ def k_modes_single(X, n_clusters, n_points, n_attrs, max_iter, dissim, init, ini
     elif isinstance(init, str) and init.lower() == 'cao':
         centroids = init_cao(X, n_clusters, dissim)
     elif isinstance(init, str) and init.lower() == 'random':
-        seeds = random_state.random.choice(range(n_points), n_clusters)
+        seeds = random_state.choice(range(n_points), n_clusters)
         centroids = X[seeds]
     elif hasattr(init, '__array__'):
         # Make sure init is a 2D array.
@@ -267,11 +267,11 @@ def k_modes(X, n_clusters, max_iter, dissim, init, n_init, verbose, random_state
     if n_jobs == 1:
         for init_no in range(n_init):
             results.append(k_modes_single(X, n_clusters, n_points, n_attrs, max_iter,
-                                          dissim, init, init_no, verbose, random_state))
+                                          dissim, init, init_no, verbose, seeds[init_no]))
     else:
         results = Parallel(n_jobs=n_jobs, verbose=0)(
             delayed(k_modes_single)(X, n_clusters, n_points, n_attrs, max_iter,
-                                    dissim, init, init_no, verbose, random_state)
+                                    dissim, init, init_no, verbose, seed)
             for init_no, seed in enumerate(seeds))
     all_centroids, all_labels, all_costs, all_n_iters = zip(*results)
 

--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -9,13 +9,15 @@ from collections import defaultdict
 import numpy as np
 from scipy import sparse
 from sklearn.base import BaseEstimator, ClusterMixin
+from sklearn.externals.joblib import Parallel, delayed
+from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_array
 
 from .util import get_max_value_key, encode_features, get_unique_rows, decode_centroids
 from .util.dissim import matching_dissim, ng_dissim
 
 
-def init_huang(X, n_clusters, dissim):
+def init_huang(X, n_clusters, dissim, random_state):
     """Initialize centroids according to method by Huang [1997]."""
     n_attrs = X.shape[1]
     centroids = np.empty((n_clusters, n_attrs), dtype='object')
@@ -34,7 +36,7 @@ def init_huang(X, n_clusters, dissim):
         # So that we are consistent between Python versions,
         # each with different dict ordering.
         choices = sorted(choices)
-        centroids[:, iattr] = np.random.choice(choices, n_clusters)
+        centroids[:, iattr] = random_state.choice(choices, n_clusters)
     # The previously chosen centroids could result in empty clusters,
     # so set centroid to closest point in X.
     for ik in range(n_clusters):
@@ -128,7 +130,7 @@ def _labels_cost(X, centroids, dissim, membship=None):
     return labels, cost
 
 
-def _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim):
+def _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim, random_state):
     """Single iteration of k-modes clustering algorithm"""
     moves = 0
     for ipoint, curpoint in enumerate(X):
@@ -150,7 +152,7 @@ def _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim):
         if not membship[old_clust, :].any():
             from_clust = membship.sum(axis=1).argmax()
             choices = [ii for ii, ch in enumerate(membship[from_clust, :]) if ch]
-            rindx = np.random.choice(choices)
+            rindx = random_state.choice(choices)
 
             cl_attr_freq, membship, centroids = move_point_cat(
                 X[rindx], rindx, old_clust, from_clust, cl_attr_freq, membship, centroids
@@ -159,9 +161,80 @@ def _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim):
     return centroids, moves
 
 
-def k_modes(X, n_clusters, max_iter, dissim, init, n_init, verbose):
-    """k-modes algorithm"""
+def k_modes_single(X, n_clusters, n_points, n_attrs, max_iter, dissim, init, init_no,
+                   verbose, random_state):
+    random_state = check_random_state(random_state)
+    # _____ INIT _____
+    if verbose:
+        print("Init: initializing centroids")
+    if isinstance(init, str) and init.lower() == 'huang':
+        centroids = init_huang(X, n_clusters, dissim, random_state)
+    elif isinstance(init, str) and init.lower() == 'cao':
+        centroids = init_cao(X, n_clusters, dissim)
+    elif isinstance(init, str) and init.lower() == 'random':
+        seeds = random_state.random.choice(range(n_points), n_clusters)
+        centroids = X[seeds]
+    elif hasattr(init, '__array__'):
+        # Make sure init is a 2D array.
+        if len(init.shape) == 1:
+            init = np.atleast_2d(init).T
+        assert init.shape[0] == n_clusters, \
+            "Wrong number of initial centroids in init ({}, should be {})." \
+                .format(init.shape[0], n_clusters)
+        assert init.shape[1] == n_attrs, \
+            "Wrong number of attributes in init ({}, should be {})." \
+                .format(init.shape[1], n_attrs)
+        centroids = np.asarray(init, dtype=np.uint8)
+    else:
+        raise NotImplementedError
 
+    if verbose:
+        print("Init: initializing clusters")
+    membship = np.zeros((n_clusters, n_points), dtype=np.uint8)
+    # cl_attr_freq is a list of lists with dictionaries that contain the
+    # frequencies of values per cluster and attribute.
+    cl_attr_freq = [[defaultdict(int) for _ in range(n_attrs)]
+                    for _ in range(n_clusters)]
+    for ipoint, curpoint in enumerate(X):
+        # Initial assignment to clusters
+        clust = np.argmin(dissim(centroids, curpoint, X=X, membship=membship))
+        membship[clust, ipoint] = 1
+        # Count attribute values per cluster.
+        for iattr, curattr in enumerate(curpoint):
+            cl_attr_freq[clust][iattr][curattr] += 1
+    # Perform an initial centroid update.
+    for ik in range(n_clusters):
+        for iattr in range(n_attrs):
+            if sum(membship[ik]) == 0:
+                # Empty centroid, choose randomly
+                centroids[ik, iattr] = random_state.choice(X[:, iattr])
+            else:
+                centroids[ik, iattr] = get_max_value_key(cl_attr_freq[ik][iattr])
+
+    # _____ ITERATION _____
+    if verbose:
+        print("Starting iterations...")
+    itr = 0
+    labels = None
+    converged = False
+    cost = np.Inf
+    while itr <= max_iter and not converged:
+        itr += 1
+        centroids, moves = _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim, random_state)
+        # All points seen in this iteration
+        labels, ncost = _labels_cost(X, centroids, dissim, membship)
+        converged = (moves == 0) or (ncost >= cost)
+        cost = ncost
+        if verbose:
+            print("Run {}, iteration: {}/{}, moves: {}, cost: {}"
+                  .format(init_no + 1, itr, max_iter, moves, cost))
+
+    return centroids, labels, cost, itr
+
+
+def k_modes(X, n_clusters, max_iter, dissim, init, n_init, verbose, random_state, n_jobs):
+    """k-modes algorithm"""
+    random_state = check_random_state(random_state)
     if sparse.issparse(X):
         raise TypeError("k-modes does not support sparse data.")
 
@@ -189,81 +262,18 @@ def k_modes(X, n_clusters, max_iter, dissim, init, n_init, verbose):
         n_clusters = n_unique
         init = unique
 
-    all_centroids = []
-    all_labels = []
-    all_costs = []
-    all_n_iters = []
-    for init_no in range(n_init):
-
-        # _____ INIT _____
-        if verbose:
-            print("Init: initializing centroids")
-        if isinstance(init, str) and init.lower() == 'huang':
-            centroids = init_huang(X, n_clusters, dissim)
-        elif isinstance(init, str) and init.lower() == 'cao':
-            centroids = init_cao(X, n_clusters, dissim)
-        elif isinstance(init, str) and init.lower() == 'random':
-            seeds = np.random.choice(range(n_points), n_clusters)
-            centroids = X[seeds]
-        elif hasattr(init, '__array__'):
-            # Make sure init is a 2D array.
-            if len(init.shape) == 1:
-                init = np.atleast_2d(init).T
-            assert init.shape[0] == n_clusters, \
-                "Wrong number of initial centroids in init ({}, should be {})."\
-                .format(init.shape[0], n_clusters)
-            assert init.shape[1] == n_attrs, \
-                "Wrong number of attributes in init ({}, should be {})."\
-                .format(init.shape[1], n_attrs)
-            centroids = np.asarray(init, dtype=np.uint8)
-        else:
-            raise NotImplementedError
-
-        if verbose:
-            print("Init: initializing clusters")
-        membship = np.zeros((n_clusters, n_points), dtype=np.uint8)
-        # cl_attr_freq is a list of lists with dictionaries that contain the
-        # frequencies of values per cluster and attribute.
-        cl_attr_freq = [[defaultdict(int) for _ in range(n_attrs)]
-                        for _ in range(n_clusters)]
-        for ipoint, curpoint in enumerate(X):
-            # Initial assignment to clusters
-            clust = np.argmin(dissim(centroids, curpoint, X=X, membship=membship))
-            membship[clust, ipoint] = 1
-            # Count attribute values per cluster.
-            for iattr, curattr in enumerate(curpoint):
-                cl_attr_freq[clust][iattr][curattr] += 1
-        # Perform an initial centroid update.
-        for ik in range(n_clusters):
-            for iattr in range(n_attrs):
-                if sum(membship[ik]) == 0:
-                    # Empty centroid, choose randomly
-                    centroids[ik, iattr] = np.random.choice(X[:, iattr])
-                else:
-                    centroids[ik, iattr] = get_max_value_key(cl_attr_freq[ik][iattr])
-
-        # _____ ITERATION _____
-        if verbose:
-            print("Starting iterations...")
-        itr = 0
-        converged = False
-        cost = np.Inf
-        while itr <= max_iter and not converged:
-            itr += 1
-            centroids, moves = _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim)
-            # All points seen in this iteration
-            labels, ncost = _labels_cost(X, centroids, dissim, membship)
-            converged = (moves == 0) or (ncost >= cost)
-            cost = ncost
-            if verbose:
-                print("Run {}, iteration: {}/{}, moves: {}, cost: {}"
-                      .format(init_no + 1, itr, max_iter, moves, cost))
-
-        # Store result of current run.
-        all_centroids.append(centroids)
-        all_labels.append(labels)
-        all_costs.append(cost)
-        all_n_iters.append(itr)
+    results = []
+    seeds = random_state.randint(np.iinfo(np.int32).max, size=n_init)
+    if n_jobs == 1:
+        for init_no in range(n_init):
+            results.append(k_modes_single(X, n_clusters, n_points, n_attrs, max_iter,
+                                          dissim, init, init_no, verbose, random_state))
+    else:
+        results = Parallel(n_jobs=n_jobs, verbose=0)(
+            delayed(k_modes_single)(X, n_clusters, n_points, n_attrs, max_iter,
+                                    dissim, init, init_no, verbose, random_state)
+            for init_no, seed in enumerate(seeds))
+    all_centroids, all_labels, all_costs, all_n_iters = zip(*results)
 
     best = np.argmin(all_costs)
     if n_init > 1 and verbose:
@@ -333,7 +343,7 @@ class KModes(BaseEstimator, ClusterMixin):
     """
 
     def __init__(self, n_clusters=8, max_iter=100, cat_dissim=matching_dissim,
-                 init='Cao', n_init=1, verbose=0):
+                 init='Cao', n_init=1, verbose=0, random_state=None, n_jobs=1):
 
         self.n_clusters = n_clusters
         self.max_iter = max_iter
@@ -341,6 +351,8 @@ class KModes(BaseEstimator, ClusterMixin):
         self.init = init
         self.n_init = n_init
         self.verbose = verbose
+        self.random_state = random_state
+        self.n_jobs = n_jobs
         if ((isinstance(self.init, str) and self.init == 'Cao') or
                 hasattr(self.init, '__array__')) and self.n_init > 1:
             if self.verbose:
@@ -356,6 +368,7 @@ class KModes(BaseEstimator, ClusterMixin):
         X : array-like, shape=[n_samples, n_features]
         """
 
+        random_state = check_random_state(self.random_state)
         self._enc_cluster_centroids, self._enc_map, self.labels_,\
             self.cost_, self.n_iter_ = k_modes(X,
                                                self.n_clusters,
@@ -363,7 +376,9 @@ class KModes(BaseEstimator, ClusterMixin):
                                                self.cat_dissim,
                                                self.init,
                                                self.n_init,
-                                               self.verbose)
+                                               self.verbose,
+                                               random_state,
+                                               self.n_jobs)
         return self
 
     def fit_predict(self, X, y=None, **kwargs):

--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -318,6 +318,20 @@ class KModes(BaseEstimator, ClusterMixin):
     verbose : int, optional
         Verbosity mode.
 
+    random_state : int, RandomState instance or None, optional, default: None
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    n_jobs : int, default: 1
+        The number of jobs to use for the computation. This works by computing
+        each of the n_init runs in parallel.
+        If -1 all CPUs are used. If 1 is given, no parallel computing code is
+        used at all, which is useful for debugging. For n_jobs below -1,
+        (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
+        are used.
+
     Attributes
     ----------
     cluster_centroids_ : array, [n_clusters, n_features]

--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -374,6 +374,20 @@ class KPrototypes(kmodes.KModes):
     verbose : integer, optional
         Verbosity mode.
 
+    random_state : int, RandomState instance or None, optional, default: None
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    n_jobs : int, default: 1
+        The number of jobs to use for the computation. This works by computing
+        each of the n_init runs in parallel.
+        If -1 all CPUs are used. If 1 is given, no parallel computing code is
+        used at all, which is useful for debugging. For n_jobs below -1,
+        (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
+        are used.
+
     Attributes
     ----------
     cluster_centroids_ : array, [n_clusters, n_features]

--- a/kmodes/tests/test_kmodes.py
+++ b/kmodes/tests/test_kmodes.py
@@ -90,12 +90,22 @@ class TestKModes(unittest.TestCase):
         assert_equal(type(pickle.loads(s)), obj.__class__)
 
     def test_kmodes_huang_soybean(self):
-        np.random.seed(42)
-        kmodes_huang = KModes(n_clusters=4, n_init=2, init='Huang', verbose=2)
+        kmodes_huang = KModes(n_clusters=4, n_init=2, init='Huang', verbose=2,
+                              random_state=42)
         result = kmodes_huang.fit_predict(SOYBEAN)
-        expected = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 1,
-                             2, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 2, 1])
+        expected = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2,
+                             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
+        assert_cluster_splits_equal(result, expected)
+        self.assertTrue(result.dtype == np.dtype(np.uint8))
+
+    def test_kmodes_huang_soybean_parallel(self):
+        kmodes_huang = KModes(n_clusters=4, n_init=4, init='Huang', verbose=2,
+                              random_state=42, n_jobs=4)
+        result = kmodes_huang.fit_predict(SOYBEAN)
+        expected = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2,
+                             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
         assert_cluster_splits_equal(result, expected)
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
@@ -124,7 +134,8 @@ class TestKModes(unittest.TestCase):
             kmodes_cao.cluster_centroids_
 
     def test_kmodes_random_soybean(self):
-        kmodes_random = KModes(n_clusters=4, init='random', verbose=2)
+        kmodes_random = KModes(n_clusters=4, init='random', verbose=2,
+                               random_state=42)
         result = kmodes_random.fit(SOYBEAN)
         self.assertIsInstance(result, KModes)
 
@@ -191,8 +202,8 @@ class TestKModes(unittest.TestCase):
             [0, 2],
             [0, 2]
         ])
-        np.random.seed(42)
-        kmodes_cao = KModes(n_clusters=6, init='Cao', verbose=2)
+        kmodes_cao = KModes(n_clusters=6, init='Cao', verbose=2,
+                            random_state=42)
         result = kmodes_cao.fit_predict(data, categorical=[1])
         expected = np.array([0, 0, 0, 1, 1, 1])
         assert_cluster_splits_equal(result, expected)
@@ -201,8 +212,8 @@ class TestKModes(unittest.TestCase):
                                                 [0, 2]]))
 
     def test_kmodes_huang_soybean_ng(self):
-        np.random.seed(42)
-        kmodes_huang = KModes(n_clusters=4, n_init=2, init='Huang', verbose=2, cat_dissim=ng_dissim)
+        kmodes_huang = KModes(n_clusters=4, n_init=2, init='Huang', verbose=2,
+                              cat_dissim=ng_dissim, random_state=42)
         result = kmodes_huang.fit_predict(SOYBEAN)
         expected = np.array([3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0,
                              0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2,
@@ -211,7 +222,8 @@ class TestKModes(unittest.TestCase):
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
     def test_kmodes_cao_soybean_ng(self):
-        kmodes_cao = KModes(n_clusters=4, init='Cao', verbose=2, cat_dissim=ng_dissim)
+        kmodes_cao = KModes(n_clusters=4, init='Cao', verbose=2,
+                            cat_dissim=ng_dissim)
         result = kmodes_cao.fit_predict(SOYBEAN)
         expected = np.array([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
                              1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0,
@@ -220,7 +232,8 @@ class TestKModes(unittest.TestCase):
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
     def test_kmodes_predict_soybean_ng(self):
-        kmodes_cao = KModes(n_clusters=4, init='Cao', verbose=2, cat_dissim=ng_dissim)
+        kmodes_cao = KModes(n_clusters=4, init='Cao', verbose=2,
+                            cat_dissim=ng_dissim)
         kmodes_cao = kmodes_cao.fit(SOYBEAN)
         result = kmodes_cao.predict(SOYBEAN2)
         expected = np.array([2, 1, 3, 0])
@@ -236,8 +249,8 @@ class TestKModes(unittest.TestCase):
             [0, 2],
             [0, 2]
         ])
-        np.random.seed(42)
-        kmodes_cao = KModes(n_clusters=6, init='Cao', verbose=2, cat_dissim=ng_dissim)
+        kmodes_cao = KModes(n_clusters=6, init='Cao', verbose=2,
+                            cat_dissim=ng_dissim, random_state=42)
         result = kmodes_cao.fit_predict(data, categorical=[1])
         expected = np.array([0, 0, 0, 1, 1, 1])
         assert_cluster_splits_equal(result, expected)

--- a/kmodes/tests/test_kprototypes.py
+++ b/kmodes/tests/test_kprototypes.py
@@ -52,8 +52,21 @@ class TestKProtoTypes(unittest.TestCase):
         self.assertIsInstance(result, kprototypes.KPrototypes)
 
     def test_kprotoypes_huang_stocks(self):
-        np.random.seed(42)
-        kproto_huang = kprototypes.KPrototypes(n_clusters=4, n_init=1, init='Huang', verbose=2)
+        kproto_huang = kprototypes.KPrototypes(n_clusters=4, n_init=1,
+                                               init='Huang', verbose=2,
+                                               random_state=42)
+        # Untrained model
+        with self.assertRaises(AssertionError):
+            kproto_huang.predict(STOCKS, categorical=[1, 2])
+        result = kproto_huang.fit_predict(STOCKS, categorical=[1, 2])
+        expected = np.array([0, 3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1])
+        assert_cluster_splits_equal(result, expected)
+        self.assertTrue(result.dtype == np.dtype(np.uint8))
+
+    def test_kprotoypes_huang_stocks_parallel(self):
+        kproto_huang = kprototypes.KPrototypes(n_clusters=4, n_init=4,
+                                               init='Huang', verbose=2,
+                                               random_state=42, n_jobs=4)
         # Untrained model
         with self.assertRaises(AssertionError):
             kproto_huang.predict(STOCKS, categorical=[1, 2])
@@ -63,16 +76,16 @@ class TestKProtoTypes(unittest.TestCase):
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
     def test_kprotoypes_cao_stocks(self):
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao',
+                                             verbose=2, random_state=42)
         result = kproto_cao.fit_predict(STOCKS, categorical=[1, 2])
         expected = np.array([2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1])
         assert_cluster_splits_equal(result, expected)
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
     def test_kprotoypes_predict_stocks(self):
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao',
+                                             verbose=2, random_state=42)
         kproto_cao = kproto_cao.fit(STOCKS, categorical=[1, 2])
         result = kproto_cao.predict(STOCKS2, categorical=[1, 2])
         expected = np.array([1, 1, 3, 1])
@@ -80,15 +93,16 @@ class TestKProtoTypes(unittest.TestCase):
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
     def test_kprototypes_predict_unfitted(self):
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao',
+                                             verbose=2, random_state=42)
         with self.assertRaises(AssertionError):
             kproto_cao.predict(STOCKS)
         with self.assertRaises(AttributeError):
             kproto_cao.cluster_centroids_
 
     def test_kprotoypes_random_stocks(self):
-        kproto_random = kprototypes.KPrototypes(n_clusters=4, init='random', verbose=2)
+        kproto_random = kprototypes.KPrototypes(n_clusters=4, init='random',
+                                                verbose=2)
         result = kproto_random.fit(STOCKS, categorical=[1, 2])
         self.assertIsInstance(result, kprototypes.KPrototypes)
 
@@ -104,7 +118,8 @@ class TestKProtoTypes(unittest.TestCase):
                       [738.5],
                       [197.667]])
         ]
-        kproto_init = kprototypes.KPrototypes(n_clusters=2, init=init_vals, verbose=2)
+        kproto_init = kprototypes.KPrototypes(n_clusters=2, init=init_vals,
+                                              verbose=2)
         with self.assertRaises(AssertionError):
             kproto_init.fit_predict(STOCKS, categorical=[1, 2])
 
@@ -116,7 +131,8 @@ class TestKProtoTypes(unittest.TestCase):
                       [3, 2],
                       [2, 2]])
         ]
-        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals, verbose=2)
+        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals,
+                                              verbose=2)
         with self.assertRaises(AssertionError):
             kproto_init.fit_predict(STOCKS, categorical=[1, 2])
 
@@ -125,7 +141,8 @@ class TestKProtoTypes(unittest.TestCase):
             np.array([356.975, 275.35, 738.5, 197.667]),
             np.array([3, 0, 3, 2])
         ]
-        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals, verbose=2)
+        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals,
+                                              verbose=2)
         with self.assertRaises(AssertionError):
             kproto_init.fit_predict(STOCKS, categorical=[1, 2])
 
@@ -139,8 +156,8 @@ class TestKProtoTypes(unittest.TestCase):
                       [3, 2],
                       [2, 2]])
         ]
-        np.random.seed(42)
-        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals, verbose=2)
+        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals,
+                                              verbose=2, random_state=42)
         result = kproto_init.fit_predict(STOCKS, categorical=[1, 2])
         expected = np.array([2, 0, 0, 0, 0, 1, 1, 1, 1, 3, 3, 3])
         assert_cluster_splits_equal(result, expected)
@@ -157,12 +174,14 @@ class TestKProtoTypes(unittest.TestCase):
                       [3, 2],
                       [2, 2]])
         ]
-        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals, verbose=2)
+        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals,
+                                              verbose=2)
         with self.assertRaises(ValueError):
             kproto_init.fit_predict(STOCKS, categorical=[1, 2])
 
     def test_kprototypes_unknowninit_soybean(self):
-        kproto = kprototypes.KPrototypes(n_clusters=4, init='nonsense', verbose=2)
+        kproto = kprototypes.KPrototypes(n_clusters=4, init='nonsense',
+                                         verbose=2)
         with self.assertRaises(NotImplementedError):
             kproto.fit(STOCKS, categorical=[1, 2])
 
@@ -194,8 +213,8 @@ class TestKProtoTypes(unittest.TestCase):
             [0, 'Regular'],
             [0, 'Regular']
         ])
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao',
+                                             verbose=2, random_state=42)
         kproto_cao = kproto_cao.fit(init_problem, categorical=[1])
         self.assertTrue(hasattr(kproto_cao, 'cluster_centroids_'))
 
@@ -205,8 +224,8 @@ class TestKProtoTypes(unittest.TestCase):
             [0., 'Regular'],
             [0., 'Slim']
         ])
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao',
+                                             verbose=2, random_state=42)
         with self.assertRaises(AssertionError):
             kproto_cao.fit_predict(data, categorical=[1])
 
@@ -219,8 +238,8 @@ class TestKProtoTypes(unittest.TestCase):
             [1., 'Slim'],
             [1., 'Slim']
         ])
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao',
+                                             verbose=2, random_state=42)
         kproto_cao.fit_predict(data, categorical=[1])
         # Check if there are only 2 clusters.
         self.assertEqual(kproto_cao.cluster_centroids_[0].shape, (2, 1))
@@ -235,20 +254,22 @@ class TestKProtoTypes(unittest.TestCase):
             [0., 'Slim'],
             [0., 'Slim']
         ])
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=2, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=2, init='Cao',
+                                             verbose=2, random_state=42)
         with self.assertRaises(ValueError):
             kproto_cao.fit_predict(data, categorical=[1])
 
     def test_kprotoypes_no_categoricals(self):
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao', verbose=2)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=6, init='Cao',
+                                             verbose=2, random_state=42)
         with self.assertRaises(NotImplementedError):
             kproto_cao.fit(STOCKS, categorical=[])
 
     def test_kprotoypes_huang_stocks_ng(self):
-        np.random.seed(42)
-        kproto_huang = kprototypes.KPrototypes(n_clusters=4, n_init=1, init='Huang', verbose=2, cat_dissim=ng_dissim)
+        kproto_huang = kprototypes.KPrototypes(n_clusters=4, n_init=1,
+                                               init='Huang', verbose=2,
+                                               cat_dissim=ng_dissim,
+                                               random_state=42)
         # Untrained model
         with self.assertRaises(AssertionError):
             kproto_huang.predict(STOCKS, categorical=[1, 2])
@@ -258,16 +279,18 @@ class TestKProtoTypes(unittest.TestCase):
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
     def test_kprotoypes_cao_stocks_ng(self):
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao', verbose=2, cat_dissim=ng_dissim)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao',
+                                             verbose=2, cat_dissim=ng_dissim,
+                                             random_state=42)
         result = kproto_cao.fit_predict(STOCKS, categorical=[1, 2])
         expected = np.array([2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1])
         assert_cluster_splits_equal(result, expected)
         self.assertTrue(result.dtype == np.dtype(np.uint8))
 
     def test_kprotoypes_predict_stocks_ng(self):
-        np.random.seed(42)
-        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao', verbose=2, cat_dissim=ng_dissim)
+        kproto_cao = kprototypes.KPrototypes(n_clusters=4, init='Cao',
+                                             verbose=2, cat_dissim=ng_dissim,
+                                             random_state=42)
         kproto_cao = kproto_cao.fit(STOCKS, categorical=[1, 2])
         result = kproto_cao.predict(STOCKS2, categorical=[1, 2])
         expected = np.array([1, 1, 3, 1])
@@ -285,8 +308,9 @@ class TestKProtoTypes(unittest.TestCase):
                       [3, 2],
                       [2, 2]])
         ]
-        np.random.seed(42)
-        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals, verbose=2, cat_dissim=ng_dissim)
+        kproto_init = kprototypes.KPrototypes(n_clusters=4, init=init_vals,
+                                              verbose=2, cat_dissim=ng_dissim,
+                                              random_state=42)
         result = kproto_init.fit_predict(STOCKS, categorical=[1, 2])
         expected = np.array([2, 0, 0, 0, 0, 1, 1, 1, 1, 3, 3, 3])
         assert_cluster_splits_equal(result, expected)


### PR DESCRIPTION
Parallel implementations of K-Modes and K-Prototypes. See #76 for more information.

The approach is mostly identical to scikit-learn's implementation of parallel K-Means. Changes are:
- allowing multi-core reproducibility by propagating random seeds to all jobs
- extracting the parallel unit of work, a single run, to a separate function
- performing units of work sequentially if `n_jobs=1`, or using joblib otherwise

Note that it only makes sense to use parallel execution for `n_init>1`. This is not enforced in code.

I updated the documentation and tests accordingly. The expected outcomes of K-Modes tests had to be changed due to the new method of seeding.

When this PR is merged, I will look into updating the examples/benchmarks to make use of the changes.