### PR TITLE
Updated readme and benchmarks for parallel execution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,20 @@ the categorical variables, but does *not* accept missing values for the
 numerical values. It is up to the user to come up with a way of
 handling these missing data that is appropriate for the problem at hand.
 
+Parallel execution
+------------------
+
+The k-modes and k-prototypes implementations both offer support for threaded
+execution via the `joblib library<https://pythonhosted.org/joblib/generated/joblib.Parallel.html>`_,
+similar to e.g. scikit-learn's implementation of k-means, using the
+:code:`n_jobs` parameter.
+
+This potentially speeds up any execution with more than one run,
+:code:`n_jobs > 1`, which may be helpful to reduce the execution time for
+larger problems. Note that it depends on your problem whether multithreading
+actually helps, so be sure to try that out first. You can check out the
+examples for some benchmarks.
+
 References
 ----------
 

--- a/examples/benchmark_parallel.py
+++ b/examples/benchmark_parallel.py
@@ -1,0 +1,81 @@
+import time
+
+import numpy as np
+
+from kmodes.kmodes import KModes
+from kmodes.kprototypes import KPrototypes
+
+
+# number of clusters
+K = 20
+# no. of points for K-Prototypes
+N_kproto = int(1e4)
+# no. of points for K-Modes
+# We set this higher than K-Prototypes, because K-Modes converges much faster
+# and we want to reduce the influence of overhead during the benchmark.
+N_kmodes = int(1e5)
+# no. of dimensions
+M = 10
+# no. of numerical dimensions
+MN = 5
+
+data = np.random.randint(1, 1000, (max(N_kproto, N_kmodes), M))
+
+
+def kprototypes():
+    # Draw a seed, so both jobs converge in an equal amount of iterations
+    seed = np.random.randint(np.iinfo(np.int32).max)
+
+    start = time.time()
+    KPrototypes(n_clusters=K, init='Huang', n_init=4, verbose=2,
+                random_state=seed) \
+        .fit(data[:N_kproto, :], categorical=list(range(M - MN, M)))
+    single = time.time() - start
+    print('Finished 4 runs on 1 thread in {:.2f} seconds'.format(single))
+
+    np.random.seed(seed)
+    start = time.time()
+    KPrototypes(n_clusters=K, init='Huang', n_init=4, n_jobs=4, verbose=2,
+                random_state=seed) \
+        .fit(data[:N_kproto, :], categorical=list(range(M - MN, M)))
+    multi = time.time() - start
+    print('Finished 4 runs on 4 threads in {:.2f} seconds'.format(multi))
+
+    return single, multi
+
+
+def kmodes():
+    # Draw a seed, so both jobs converge in an equal amount of iterations
+    seed = np.random.randint(np.iinfo(np.int32).max)
+
+    start = time.time()
+    KModes(n_clusters=K, init='Huang', n_init=4, verbose=2,
+           random_state=seed).fit(data[:N_kmodes, :])
+    single = time.time() - start
+    print('Finished 4 runs on 1 thread in {:.2f} seconds'.format(single))
+
+    start = time.time()
+    KModes(n_clusters=K, init='Huang', n_init=4, n_jobs=4, verbose=2,
+           random_state=seed).fit(data[:N_kmodes, :])
+    multi = time.time() - start
+    print('Finished 4 runs on 4 threads in {:.2f} seconds'.format(multi))
+
+    return single, multi
+
+
+if __name__ == '__main__':
+    print('Starting K-Prototypes on 1 and on 4 threads for {} clusters with {}'
+          ' points of {} features'.format(K, N_kproto, M))
+    res_kproto = kprototypes()
+    print('Starting K-Modes on 1 and on 4 threads for {} clusters with {}'
+          ' points of {} features'.format(K, N_kmodes, M))
+    res_kmodes = kmodes()
+    print()
+    print('K-Protoypes took {:.2f} s for 1 thread and {:.2f} s for 4 threads:'
+          ' a {:.1f}x speed-up'.format(res_kproto[0], res_kproto[1],
+                                       res_kproto[0] / res_kproto[1]))
+    print('K-Modes took {:.2f} s for 1 thread and {:.2f} s for 4 threads:'
+          ' a {:.1f}x speed-up'.format(res_kmodes[0], res_kmodes[1],
+                                       res_kmodes[0] / res_kmodes[1]))
+
+


### PR DESCRIPTION
I think the readme speaks for itself. 
The benchmarking script simply runs four executions of both k-modes and k-prototypes on a single core and then on four, with random data, like the other benchmarks. I'm getting speedups for both problems of around 2.5 to 3x, which is decent, but definitely indicates a bottleneck of some sort. It likely has to do with four threads trying to access the same bit of memory.
The code isn't the cleanest, but it gets the job done, so I think it should suffice.

Let me know what you think!