### PR TITLE
joblib dependency

### DIFF
--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -7,9 +7,9 @@ K-modes clustering for categorical data
 from collections import defaultdict
 
 import numpy as np
+from joblib import Parallel, delayed
 from scipy import sparse
 from sklearn.base import BaseEstimator, ClusterMixin
-from sklearn.externals.joblib import Parallel, delayed
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_array
 

--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -7,8 +7,8 @@ K-prototypes clustering for mixed categorical and numerical data
 from collections import defaultdict
 
 import numpy as np
+from joblib import Parallel, delayed
 from scipy import sparse
-from sklearn.externals.joblib import Parallel, delayed
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_array
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'numpy>=1.10.4',
         'scikit-learn>=0.19.0',
         'scipy>=0.13.3',
+        'joblib>=0.11'
     ],
     classifiers=['Development Status :: 3 - Alpha',
                  'Intended Audience :: Science/Research',


### PR DESCRIPTION
scikit-learn/scikit-learn#13531 removed the vendored joblib from future version of scikit-learn. This is not in a stable release yet, but shall be soon enough.