### PR TITLE
Change feature array initialization dtype to uint32

### DIFF
--- a/kmodes/util/__init__.py
+++ b/kmodes/util/__init__.py
@@ -39,7 +39,7 @@ def encode_features(X, enc_map=None):
     else:
         fit = False
 
-    Xenc = np.zeros(X.shape).astype('int')
+    Xenc = np.zeros(X.shape, dtype='uint32')
     for ii in range(X.shape[1]):
         if fit:
             col_enc = {val: jj for jj, val in enumerate(np.unique(X[:, ii]))


### PR DESCRIPTION
Modifying feature array initialization dtype from float64 to uint32 should reduce overall memory usage in initialization.

Ran unit tests before and after change with no issues.

(Per https://github.com/nicodv/kmodes/issues/165)
