### PR TITLE
Add sample weights to KPrototypes.

### DIFF
--- a/examples/people.csv
+++ b/examples/people.csv
@@ -1,0 +1,4 @@
+Marc, .2, -2, A
+Martine, -.2, 0, A
+Max, .2, .2, A
+Maxine, .2, .1, A

--- a/examples/people.py
+++ b/examples/people.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import numpy as np
+from kmodes.kprototypes import KPrototypes
+
+# stocks with their market caps, sectors and countries
+syms = np.genfromtxt('people.csv', dtype=str, delimiter=',')[:, 0]
+X = np.genfromtxt('people.csv', dtype=object, delimiter=',')[:, 1:]
+X[:, 0] = X[:, 0].astype(float)
+
+weights = [1] * 4
+weights[2] = 100
+weights[3] = 100
+
+kproto = KPrototypes(n_clusters=3, init='Cao', verbose=2, sample_weights=weights)
+clusters = kproto.fit_predict(X, categorical=[2])
+
+# Print cluster centroids of the trained model.
+print(kproto.cluster_centroids_)
+# Print training statistics
+print(kproto.cost_)
+print(kproto.n_iter_)
+
+for s, c in zip(syms, clusters):
+    print(f"Symbol: {s}, cluster:{c}")

--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -361,7 +361,7 @@ def _k_modes_iter(X, centroids, cl_attr_freq, membship, dissim, random_state):
 
 
 def _move_point_cat(point, ipoint, to_clust, from_clust, cl_attr_freq,
-                    membship, centroids):
+                    membship, centroids, sample_weight=1):
     """Move point between clusters, categorical attributes."""
     membship[to_clust, ipoint] = 1
     membship[from_clust, ipoint] = 0
@@ -371,7 +371,7 @@ def _move_point_cat(point, ipoint, to_clust, from_clust, cl_attr_freq,
         from_attr_counts = cl_attr_freq[from_clust][iattr]
 
         # Increment the attribute count for the new "to" cluster
-        to_attr_counts[curattr] += 1
+        to_attr_counts[curattr] += sample_weight
 
         current_attribute_value_freq = to_attr_counts[curattr]
         current_centroid_value = centroids[to_clust][iattr]
@@ -381,7 +381,7 @@ def _move_point_cat(point, ipoint, to_clust, from_clust, cl_attr_freq,
             centroids[to_clust][iattr] = curattr
 
         # Decrement the attribute count for the old "from" cluster
-        from_attr_counts[curattr] -= 1
+        from_attr_counts[curattr] -= sample_weight
 
         old_centroid_value = centroids[from_clust][iattr]
         if old_centroid_value == curattr:

--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -227,7 +227,7 @@ def labels_cost(Xnum, Xcat, centroids, num_dissim, cat_dissim, gamma, membship=N
         tot_costs = num_costs + gamma * cat_costs
         clust = np.argmin(tot_costs)
         labels[ipoint] = clust
-        if sample_weights:
+        if sample_weights is not None:
             cost += tot_costs[clust] * sample_weights[ipoint]
         else:
             cost += tot_costs[clust]

--- a/kmodes/kprototypes.py
+++ b/kmodes/kprototypes.py
@@ -116,12 +116,13 @@ class KPrototypes(kmodes.KModes):
 
     def __init__(self, n_clusters=8, max_iter=100, num_dissim=euclidean_dissim,
                  cat_dissim=matching_dissim, init='Cao', n_init=10, gamma=None,
-                 verbose=0, random_state=None, n_jobs=1):
+                 verbose=0, random_state=None, n_jobs=1, sample_weights=None):
 
         super(KPrototypes, self).__init__(n_clusters, max_iter, cat_dissim, init,
                                           verbose=verbose, random_state=random_state,
                                           n_jobs=n_jobs)
         self.num_dissim = num_dissim
+        self.sample_weights = sample_weights
         self.gamma = gamma
         self.n_init = n_init
         if isinstance(self.init, list) and self.n_init > 1:
@@ -162,7 +163,8 @@ class KPrototypes(kmodes.KModes):
             self.n_init,
             self.verbose,
             random_state,
-            self.n_jobs
+            self.n_jobs,
+            self.sample_weights,
         )
 
         return self
@@ -194,7 +196,7 @@ class KPrototypes(kmodes.KModes):
         Xnum, Xcat = check_array(Xnum), check_array(Xcat, dtype=None)
         Xcat, _ = encode_features(Xcat, enc_map=self._enc_map)
         return labels_cost(Xnum, Xcat, self._enc_cluster_centroids,
-                           self.num_dissim, self.cat_dissim, self.gamma)[0]
+                           self.num_dissim, self.cat_dissim, self.gamma, self.sample_weights)[0]
 
     @property
     def cluster_centroids_(self):
@@ -207,7 +209,7 @@ class KPrototypes(kmodes.KModes):
                              "because the model is not yet fitted.")
 
 
-def labels_cost(Xnum, Xcat, centroids, num_dissim, cat_dissim, gamma, membship=None):
+def labels_cost(Xnum, Xcat, centroids, num_dissim, cat_dissim, gamma, membship=None, sample_weights=None):
     """Calculate labels and cost function given a matrix of points and
     a list of centroids for the k-prototypes algorithm.
     """
@@ -225,13 +227,16 @@ def labels_cost(Xnum, Xcat, centroids, num_dissim, cat_dissim, gamma, membship=N
         tot_costs = num_costs + gamma * cat_costs
         clust = np.argmin(tot_costs)
         labels[ipoint] = clust
-        cost += tot_costs[clust]
+        if sample_weights:
+            cost += tot_costs[clust] * sample_weights[ipoint]
+        else:
+            cost += tot_costs[clust]
 
     return labels, cost
 
 
 def k_prototypes(X, categorical, n_clusters, max_iter, num_dissim, cat_dissim,
-                 gamma, init, n_init, verbose, random_state, n_jobs):
+                 gamma, init, n_init, verbose, random_state, n_jobs, sample_weights=None):
     """k-prototypes algorithm"""
     random_state = check_random_state(random_state)
     if sparse.issparse(X):
@@ -286,13 +291,13 @@ def k_prototypes(X, categorical, n_clusters, max_iter, num_dissim, cat_dissim,
             results.append(_k_prototypes_single(Xnum, Xcat, nnumattrs, ncatattrs,
                                                 n_clusters, n_points, max_iter,
                                                 num_dissim, cat_dissim, gamma,
-                                                init, init_no, verbose, seeds[init_no]))
+                                                init, init_no, verbose, seeds[init_no], sample_weights))
     else:
         results = Parallel(n_jobs=n_jobs, verbose=0)(
             delayed(_k_prototypes_single)(Xnum, Xcat, nnumattrs, ncatattrs,
                                           n_clusters, n_points, max_iter,
                                           num_dissim, cat_dissim, gamma,
-                                          init, init_no, verbose, seed)
+                                          init, init_no, verbose, seed, sample_weights)
             for init_no, seed in enumerate(seeds))
     all_centroids, all_labels, all_costs, all_n_iters, all_epoch_costs = zip(*results)
 
@@ -307,7 +312,7 @@ def k_prototypes(X, categorical, n_clusters, max_iter, num_dissim, cat_dissim,
 
 def _k_prototypes_single(Xnum, Xcat, nnumattrs, ncatattrs, n_clusters, n_points,
                          max_iter, num_dissim, cat_dissim, gamma, init, init_no,
-                         verbose, random_state):
+                         verbose, random_state, sample_weights=None):
     # For numerical part of initialization, we don't have a guarantee
     # that there is not an empty cluster, so we need to retry until
     # there is none.
@@ -370,18 +375,19 @@ def _k_prototypes_single(Xnum, Xcat, nnumattrs, ncatattrs, n_clusters, n_points,
         cl_attr_freq = [[defaultdict(int) for _ in range(ncatattrs)]
                         for _ in range(n_clusters)]
         for ipoint in range(n_points):
+            sample_weight = sample_weights[ipoint] if sample_weights is not None else 1
             # Initial assignment to clusters
             clust = np.argmin(
                 num_dissim(centroids[0], Xnum[ipoint]) + gamma *
                 cat_dissim(centroids[1], Xcat[ipoint], X=Xcat, membship=membship)
             )
             membship[clust, ipoint] = 1
-            cl_memb_sum[clust] += 1
+            cl_memb_sum[clust] += sample_weight
             # Count attribute values per cluster.
             for iattr, curattr in enumerate(Xnum[ipoint]):
-                cl_attr_sum[clust, iattr] += curattr
+                cl_attr_sum[clust, iattr] += curattr * sample_weight
             for iattr, curattr in enumerate(Xcat[ipoint]):
-                cl_attr_freq[clust][iattr][curattr] += 1
+                cl_attr_freq[clust][iattr][curattr] += sample_weight
 
         # If no empty clusters, then consider initialization finalized.
         if membship.sum(axis=1).min() > 0:
@@ -412,7 +418,7 @@ def _k_prototypes_single(Xnum, Xcat, nnumattrs, ncatattrs, n_clusters, n_points,
     converged = False
 
     _, cost = labels_cost(Xnum, Xcat, centroids,
-                          num_dissim, cat_dissim, gamma, membship)
+                          num_dissim, cat_dissim, gamma, membship, sample_weights)
 
     epoch_costs = [cost]
     while itr < max_iter and not converged:
@@ -420,11 +426,11 @@ def _k_prototypes_single(Xnum, Xcat, nnumattrs, ncatattrs, n_clusters, n_points,
         centroids, moves = _k_prototypes_iter(Xnum, Xcat, centroids,
                                               cl_attr_sum, cl_memb_sum, cl_attr_freq,
                                               membship, num_dissim, cat_dissim, gamma,
-                                              random_state)
+                                              random_state, sample_weights)
 
         # All points seen in this iteration
         labels, ncost = labels_cost(Xnum, Xcat, centroids,
-                                    num_dissim, cat_dissim, gamma, membship)
+                                    num_dissim, cat_dissim, gamma, membship, sample_weights)
         converged = (moves == 0) or (ncost >= cost)
         epoch_costs.append(ncost)
         cost = ncost
@@ -436,10 +442,11 @@ def _k_prototypes_single(Xnum, Xcat, nnumattrs, ncatattrs, n_clusters, n_points,
 
 
 def _k_prototypes_iter(Xnum, Xcat, centroids, cl_attr_sum, cl_memb_sum, cl_attr_freq,
-                       membship, num_dissim, cat_dissim, gamma, random_state):
+                       membship, num_dissim, cat_dissim, gamma, random_state, sample_weights):
     """Single iteration of the k-prototypes algorithm"""
     moves = 0
     for ipoint in range(Xnum.shape[0]):
+        sample_weight = sample_weights[ipoint] if sample_weights is not None else 1
         clust = np.argmin(
             num_dissim(centroids[0], Xnum[ipoint]) +
             gamma * cat_dissim(centroids[1], Xcat[ipoint], X=Xcat, membship=membship)
@@ -455,12 +462,12 @@ def _k_prototypes_iter(Xnum, Xcat, centroids, cl_attr_sum, cl_memb_sum, cl_attr_
         # Note that membship gets updated by kmodes.move_point_cat.
         # move_point_num only updates things specific to the k-means part.
         cl_attr_sum, cl_memb_sum = _move_point_num(
-            Xnum[ipoint], clust, old_clust, cl_attr_sum, cl_memb_sum
+            Xnum[ipoint], clust, old_clust, cl_attr_sum, cl_memb_sum, sample_weight
         )
         # noinspection PyProtectedMember
         cl_attr_freq, membship, centroids[1] = kmodes._move_point_cat(
             Xcat[ipoint], ipoint, clust, old_clust,
-            cl_attr_freq, membship, centroids[1]
+            cl_attr_freq, membship, centroids[1], sample_weight
         )
 
         # Update old and new centroids for numerical attributes using
@@ -490,15 +497,15 @@ def _k_prototypes_iter(Xnum, Xcat, centroids, cl_attr_sum, cl_memb_sum, cl_attr_
     return centroids, moves
 
 
-def _move_point_num(point, to_clust, from_clust, cl_attr_sum, cl_memb_sum):
+def _move_point_num(point, to_clust, from_clust, cl_attr_sum, cl_memb_sum, sample_weight=1):
     """Move point between clusters, numerical attributes."""
     # Update sum of attributes in cluster.
     for iattr, curattr in enumerate(point):
-        cl_attr_sum[to_clust][iattr] += curattr
-        cl_attr_sum[from_clust][iattr] -= curattr
+        cl_attr_sum[to_clust][iattr] += curattr * sample_weight
+        cl_attr_sum[from_clust][iattr] -= curattr * sample_weight
     # Update sums of memberships in cluster
-    cl_memb_sum[to_clust] += 1
-    cl_memb_sum[from_clust] -= 1
+    cl_memb_sum[to_clust] += sample_weight
+    cl_memb_sum[from_clust] -= sample_weight
     return cl_attr_sum, cl_memb_sum
 
 


### PR DESCRIPTION
As of now, every data point contributes equally to the loss function and derived cluster updates.

Yet, in some use cases, it might be desirable to attach weights to data points. 

This PR introduces `sample_weights`, a sequence of numeric values, as an optional parameter for `KPrototypes`' `fit` method as well as all downstream functions.

Some basic input validation as well as some testing are provided.