### PR TITLE
Add class check when setting n_init inside K-modes constructor

### DIFF
--- a/kmodes/kmodes.py
+++ b/kmodes/kmodes.py
@@ -102,16 +102,17 @@ class KModes(BaseEstimator, ClusterMixin):
         self.max_iter = max_iter
         self.cat_dissim = cat_dissim
         self.init = init
-        self.n_init = n_init
         self.verbose = verbose
         self.random_state = random_state
         self.n_jobs = n_jobs
-        if ((isinstance(self.init, str) and self.init == 'Cao') or
-                hasattr(self.init, '__array__')) and self.n_init > 1:
-            if self.verbose:
-                print("Initialization method and algorithm are deterministic. "
-                      "Setting n_init to 1.")
-            self.n_init = 1
+        if self.__class__ == KModes:
+            self.n_init = n_init
+            if ((isinstance(self.init, str) and self.init == 'Cao') or
+                    hasattr(self.init, '__array__')) and self.n_init > 1:
+                if self.verbose:
+                    print("Initialization method and algorithm are deterministic. "
+                        "Setting n_init to 1.")
+                self.n_init = 1
 
     def fit(self, X, y=None, sample_weight=None, **kwargs):
         """Compute k-modes clustering.


### PR DESCRIPTION
Currently, when creating a `KPrototypes` instance, there's a misleading message, which says that n_init is 1, when it's actually not:

<img width="556" alt="image" src="https://user-images.githubusercontent.com/6100882/233254149-ccb4c2ef-8381-4eae-96a9-48f668e2f1a4.png">

This occurs because n_init is actually being set twice: once within `KPrototypes.__init__()` and once again within `KModes.__init__()` as a result of the `super(KPrototypes, self).__init__(...)` call.

I'm adding a check within the `KModes.__init__()` method that actually checks that it's being called from `KModes`, and only do the `n_init` logic in that case. Now, the "Initialization method and algorithm are deterministic. Setting n_init to 1." is only printed when initializing K-modes with the `Cao` init, but suppressed when initializing K-prototypes.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/6100882/233254840-7190b0f0-0995-4c48-8913-a54780863f39.png">
